### PR TITLE
Team docent mag niet disabled zijn

### DIFF
--- a/createTeam.pl
+++ b/createTeam.pl
@@ -70,6 +70,7 @@ my $dbh = DBI->connect($dsn, $db_user, $db_pass, { RaiseError => 1 })
 my $sth_team_gemaakt = $dbh->prepare('Update teamcreated Set team_gemaakt = ? Where rowid = ?'); 
 my $sth_general = $dbh->prepare('Update teamcreated Set general_checked = ? Where rowid = ?'); 
 my $sth_writeback_members = $dbh->prepare('Update teamcreated Set members = ? Where rowid = ?');
+my $sth_delete_entry = $dbh->prepare('Delete From teamcreated Where rowid = ?');
 
 my $groups_object = MsGroups->new(
     'app_id'        => $config{'APP_ID'},
@@ -157,6 +158,9 @@ sub groupsToTeams {
             $sth_team_gemaakt->execute(encode_json(localtime->epoch), $ident);
         }else{
             $logger->make_log("$FindBin::Script ERROR Group transitie: $result->{'naam'} ". $result->decoded_content);
+            # Als het record blijft staan dan zal prodWrapper nooit meer starten
+            # $sth_delete_entry = $dbh->prepare('Delete From teamcreate Where rowid = ?');
+            $sth_delete_entry->execute($ident);
         }
     });
     TRANSITIE:

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -8,7 +8,8 @@ Create Table If Not Exists users(
     stamnr Text,
     naam Text,
     locatie Text,
-    type Text
+    type Text,
+    active Integer  Default 1
 );
 
 --

--- a/getMagister.pl
+++ b/getMagister.pl
@@ -71,7 +71,8 @@ my $TeamsHoH; # ipv zoeken in de database
 
 # Users
 # Users dient als zoek hash 
-my $sth_users = $dbh->prepare("Select azureid,upn,ROWID From users");
+# Alleen active users in de resultset issue 12
+my $sth_users = $dbh->prepare("Select azureid,upn,ROWID From users Where active = 1");
 $sth_users->execute();
 my $usersByUpn = $sth_users->fetchall_hashref('upn');
 
@@ -125,7 +126,7 @@ sub Docenten {
                 $sth_magisterdocentenrooster->execute($rowidDoc,$rowidTeam);
             }else{
         #         say Dumper $lesgroep;
-                $logger->make_log("$FindBin::Script WARNING Docent => $lesgroep->{'email'} bestaat niet in Azure");
+                $logger->make_log("$FindBin::Script WARNING Docent => ".$lesgroep->{"\x{feff}email"}." bestaat niet in Azure of is niet aktief");
             }
         # }else{
         #     say "Niet aktief";

--- a/getUsers.pl
+++ b/getUsers.pl
@@ -58,7 +58,7 @@ if (
 
 # users
 $dbh->do('Delete From users'); # Truncate the table 
-my $qry = "Insert Into users (upn, azureid, naam, locatie,stamnr,type) values (?,?,?,?,?,?) ";
+my $qry = "Insert Into users (upn, azureid, naam, locatie,stamnr,type,active) values (?,?,?,?,?,?,?) ";
 my $sth_users_add = $dbh->prepare($qry);
 
 my $users_object = MsUsers->new(
@@ -69,7 +69,7 @@ my $users_object = MsUsers->new(
 	'graph_endpoint'=> $config{'GRAPH_ENDPOINT'},
 	#'filter'        => '$filter=endswith(mail,\'atlascollege.nl\')', 
 	#'filter'        => '$filter=userType eq \'Member\'', 
-    'select'        => '$select=id,displayName,userPrincipalName,Department,employeeId',
+    'select'        => '$select=id,displayName,userPrincipalName,Department,employeeId,accountEnabled',
 	#'consistencylevel' => 'eventual',
 );
 
@@ -91,13 +91,15 @@ foreach my $user (@{$users}){
 	}else{
 		$type = 'staf';
 	}
+	my $active = $user->{'accountEnabled'};
 	$sth_users_add->execute(
 		lc($user->{'userPrincipalName'}),
 		$user->{'id'},
 		$user->{'displayName'},
 		$locatie,
 		$user->{'employeeId'},
-		$type
+		$type,
+		$active
 	); # unless ($locatie eq '99')
 }
 $logger->make_log("$FindBin::Script INFO einde");


### PR DESCRIPTION
Fixes #12
- schema: users.active toegevoegd
- getUsers: haalt nu ook active status op
- getMagister: kijkt alleen naar active users
Aanvullend:
- Verwijder team uit teamcreated als de transitie niet lukt, dit blokkeerde een prodRun
-